### PR TITLE
Deprecate usage of skyaxes plotting functions access from skyproj

### DIFF
--- a/skyproj/_skyproj.py
+++ b/skyproj/_skyproj.py
@@ -489,10 +489,16 @@ class _Skyproj():
             self._redraw_dict['im'].remove()
             self._redraw_dict['im'] = None
 
-        im = self.pcolormesh(lon_raster, lat_raster, values_raster,
-                             norm=norm, vmin=vmin, vmax=vmax,
-                             rasterized=self._redraw_dict['rasterized'],
-                             **self._redraw_dict['kwargs_pcolormesh'])
+        im = self._ax.pcolormesh(
+            lon_raster,
+            lat_raster,
+            values_raster,
+            norm=norm,
+            vmin=vmin,
+            vmax=vmax,
+            rasterized=self._redraw_dict['rasterized'],
+            **self._redraw_dict['kwargs_pcolormesh'],
+        )
         self._redraw_dict['im'] = im
         self._ax._sci(im)
 
@@ -660,11 +666,11 @@ class _Skyproj():
             Additional keywords passed to plot.
         """
         if linestyle is not None and edgecolor is not None:
-            self.plot(np.append(lon, lon[0]),
-                      np.append(lat, lat[0]),
-                      color=edgecolor, linestyle=linestyle, **kwargs)
+            self._ax.plot(np.append(lon, lon[0]),
+                          np.append(lat, lat[0]),
+                          color=edgecolor, linestyle=linestyle, **kwargs)
         if facecolor is not None:
-            self.fill(lon, lat, color=facecolor, **kwargs)
+            self.ax.fill(lon, lat, color=facecolor, **kwargs)
 
     def draw_polygon_file(self, filename, reverse=True,
                           edgecolor='red', linestyle='solid', **kwargs):
@@ -753,7 +759,7 @@ class _Skyproj():
         elif lon_range_set and lat_range_set:
             self.set_extent([lon_range[1], lon_range[0], lat_range[0], lat_range[1]])
 
-        im = self.pcolormesh(
+        im = self._ax.pcolormesh(
             lon_raster,
             lat_raster,
             values_raster,
@@ -834,7 +840,7 @@ class _Skyproj():
         elif lon_range_set and lat_range_set:
             self.set_extent([lon_range[1], lon_range[0], lat_range[0], lat_range[1]])
 
-        im = self.pcolormesh(
+        im = self._ax.pcolormesh(
             lon_raster,
             lat_raster,
             values_raster,
@@ -916,7 +922,7 @@ class _Skyproj():
         elif lon_range_set and lat_range_set:
             self.set_extent([lon_range[1], lon_range[0], lat_range[0], lat_range[1]])
 
-        im = self.pcolormesh(
+        im = self._ax.pcolormesh(
             lon_raster,
             lat_raster,
             values_raster,
@@ -1174,7 +1180,7 @@ class _Skyproj():
             lon = glon
             lat = glat
 
-        self.plot(lon, lat, linewidth=linewidth, color=color, linestyle=linestyle, **kwargs)
+        self._ax.plot(lon, lat, linewidth=linewidth, color=color, linestyle=linestyle, **kwargs)
         # pop any labels
         kwargs.pop('label', None)
         if width > 0:
@@ -1187,8 +1193,8 @@ class _Skyproj():
                 else:
                     lon = glon
                     lat = glat + delta
-                self.plot(lon, lat, linewidth=1.0, color=color,
-                          linestyle='--', **kwargs)
+                self._ax.plot(lon, lat, linewidth=1.0, color=color,
+                              linestyle='--', **kwargs)
 
     def tissot_indicatrices(self, radius=5.0, num_lon=9, num_lat=5, color='red', alpha=0.5):
         """Draw Tissot indicatrices.

--- a/skyproj/_skyproj.py
+++ b/skyproj/_skyproj.py
@@ -616,21 +616,51 @@ class _Skyproj():
         return [lon_max, lon_min, lat_min, lat_max]
 
     def plot(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.plot() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.plot()",
+            FutureWarning,
+        )
         return self._ax.plot(*args, **kwargs)
 
     def scatter(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.scatter() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.scatter()",
+            FutureWarning,
+        )
         return self._ax.scatter(*args, **kwargs)
 
     def pcolormesh(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.pcolormesh() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.pcolormesh()",
+            FutureWarning,
+        )
         return self._ax.pcolormesh(*args, **kwargs)
 
     def fill(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.fill() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.fill()",
+            FutureWarning,
+        )
         return self._ax.fill(*args, **kwargs)
 
     def circle(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.circle() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.circle()",
+            FutureWarning,
+        )
         return self._ax.circle(*args, **kwargs)
 
     def ellipse(self, *args, **kwargs):
+        warnings.warn(
+            "skyproj.ellipse() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.ellipse()",
+            FutureWarning,
+        )
         return self._ax.ellipse(*args, **kwargs)
 
     def legend(self, *args, loc='upper left', zorder=GRIDLINES_ZORDER_DEFAULT + 1, **kwargs):
@@ -639,6 +669,11 @@ class _Skyproj():
         By default the legend will be placed on top of all other elements. This
         can be adjusted with the zorder parameter.
         """
+        warnings.warn(
+            "skyproj.legend() has been deprecated and will be removed in v2.5. "
+            "Please access via skyproj.ax.legend()",
+            FutureWarning,
+        )
         legend = self._ax.legend(*args, loc=loc, **kwargs)
         legend.set_zorder(zorder)
         return legend

--- a/skyproj/skyaxes.py
+++ b/skyproj/skyaxes.py
@@ -409,6 +409,12 @@ class SkyAxes(matplotlib.axes.Axes):
 
         return result
 
+    def legend(self, *args, loc="upper left", zorder=GRIDLINES_ZORDER_DEFAULT + 1, **kwargs):
+        legend = super().legend(*args, loc=loc, **kwargs)
+        legend.set_zorder(zorder)
+
+        return legend
+
     @_add_lonlat
     def circle(self, lon, lat, radius, nsamp=100, fill=False, **kwargs):
         """Draw a geodesic circle centered at given position.

--- a/tests/test_lines_polygons.py
+++ b/tests/test_lines_polygons.py
@@ -50,7 +50,7 @@ def test_lines_polygons_mcbryde(tmp_path, lon_0):
     sp.ellipse(60, 15, 10, 4, 0, color='green', label='Nine')
     sp.ellipse(300, 15, 15, 2, 45, fill=True, color='red', label='Ten')
 
-    sp.legend()
+    sp.ax.legend()
     fname = f'lines_and_polygons_{lon_0}.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)
@@ -92,7 +92,7 @@ def test_lines_polygons_obmoll(tmp_path, lonlatplonp):
     sp.draw_polygon([160, 200, 200, 160], [-20, -20, -40, -40],
                     edgecolor='red', facecolor='black', linestyle='-', label='Six')
 
-    sp.legend()
+    sp.ax.legend()
     fname = f'lines_and_polygons_obmoll_{lon_0}_{lat_p}_{lon_p}.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)
@@ -118,7 +118,7 @@ def test_lines_polygons_mcbryde_opaque_legend(tmp_path):
     sp.draw_polygon([160, 200, 200, 160], [20, 20, 40, 40],
                     edgecolor='black', label='Four')
 
-    sp.legend(loc='lower right', framealpha=1.0)
+    sp.ax.legend(loc='lower right', framealpha=1.0)
     fname = 'lines_and_polygons_opaque_legend.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)

--- a/tests/test_lines_polygons.py
+++ b/tests/test_lines_polygons.py
@@ -27,8 +27,8 @@ def test_lines_polygons_mcbryde(tmp_path, lon_0):
     sp = skyproj.McBrydeSkyproj(ax=ax, lon_0=lon_0)
 
     # Draw two geodesics, one of which will wrap around.
-    sp.plot([-10., 45.], [-10., 45.], 'r-', label='One')
-    sp.plot([170., 210.], [-10., 45.], 'b--', label='Two')
+    sp.ax.plot([-10., 45.], [-10., 45.], 'r-', label='One')
+    sp.ax.plot([170., 210.], [-10., 45.], 'b--', label='Two')
 
     # Draw two unfilled polygons, one of which will wrap around.
     sp.draw_polygon([-20, 20, 20, -20], [20, 20, 40, 40],
@@ -43,12 +43,12 @@ def test_lines_polygons_mcbryde(tmp_path, lon_0):
                     edgecolor='red', facecolor='black', linestyle='-', label='Six')
 
     # Draw two circles, one empty, one filled.
-    sp.circle(40.0, -40.0, 5.0, color='blue', label='Seven')
-    sp.circle(-40.0, -40.0, 5.0, color='orange', label='Eight', fill=True)
+    sp.ax.circle(40.0, -40.0, 5.0, color='blue', label='Seven')
+    sp.ax.circle(-40.0, -40.0, 5.0, color='orange', label='Eight', fill=True)
 
     # Test ``ellipse``.  We can only plot one point per call
-    sp.ellipse(60, 15, 10, 4, 0, color='green', label='Nine')
-    sp.ellipse(300, 15, 15, 2, 45, fill=True, color='red', label='Ten')
+    sp.ax.ellipse(60, 15, 10, 4, 0, color='green', label='Nine')
+    sp.ax.ellipse(300, 15, 15, 2, 45, fill=True, color='red', label='Ten')
 
     sp.ax.legend()
     fname = f'lines_and_polygons_{lon_0}.png'
@@ -76,8 +76,8 @@ def test_lines_polygons_obmoll(tmp_path, lonlatplonp):
     sp = skyproj.ObliqueMollweideSkyproj(ax=ax, lon_0=lon_0, lat_p=lat_p, lon_p=lon_p)
 
     # Draw two geodesics, one of which will wrap around.
-    sp.plot([-10., 45.], [-10., 45.], 'r-', label='One')
-    sp.plot([170., 210.], [-10., 45.], 'b--', label='Two')
+    sp.ax.plot([-10., 45.], [-10., 45.], 'r-', label='One')
+    sp.ax.plot([170., 210.], [-10., 45.], 'b--', label='Two')
 
     # Draw two unfilled polygons, one of which will wrap around.
     sp.draw_polygon([-20, 20, 20, -20], [20, 20, 40, 40],
@@ -110,8 +110,8 @@ def test_lines_polygons_mcbryde_opaque_legend(tmp_path):
     ax = fig.add_subplot(111)
     sp = skyproj.McBrydeSkyproj(ax=ax, lon_0=0.0)
 
-    sp.plot([-10., 45.], [-10., 45.], 'r-', label='One')
-    sp.plot([170., 210.], [-10., 45.], 'b--', label='Two')
+    sp.ax.plot([-10., 45.], [-10., 45.], 'r-', label='One')
+    sp.ax.plot([170., 210.], [-10., 45.], 'b--', label='Two')
 
     sp.draw_polygon([-20, 20, 20, -20], [20, 20, 40, 40],
                     edgecolor='magenta', label='Three')

--- a/tests/test_milky_way.py
+++ b/tests/test_milky_way.py
@@ -21,7 +21,7 @@ def test_draw_milky_way(tmp_path):
     ax = fig.add_subplot(111)
     sp = skyproj.McBrydeSkyproj(ax=ax)
     sp.draw_milky_way(label='Milky Way')
-    sp.legend()
+    sp.ax.legend()
     fname = 'milky_way.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)
@@ -39,7 +39,7 @@ def test_draw_milky_way_galactic(tmp_path):
     ax = fig.add_subplot(111)
     sp = skyproj.McBrydeSkyproj(ax=ax, galactic=True, longitude_ticks='symmetric')
     sp.draw_milky_way(label='Milky Way')
-    sp.legend()
+    sp.ax.legend()
     fname = 'milky_way_galactic.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -26,20 +26,20 @@ def test_skyproj_plotting(tmp_path):
     sp = skyproj.McBrydeSkyproj(ax=ax, extent=[0, 50, 0, 50])
 
     # Test ``plot`` with points.
-    sp.plot([10, 20, 30, 40], [10, 20, 30, 40], 'k+')
-    sp.plot([40, 30, 20, 10], [10, 20, 30, 40], 'r.')
+    sp.ax.plot([10, 20, 30, 40], [10, 20, 30, 40], 'k+')
+    sp.ax.plot([40, 30, 20, 10], [10, 20, 30, 40], 'r.')
 
     # Test ``plot`` with lines.
     # Note that the geodesic line segments do not meet the interior
     # points plotted above.
-    sp.plot([10, 40], [10, 40], 'k-')
-    sp.plot([40, 10], [10, 40], 'r:')
+    sp.ax.plot([10, 40], [10, 40], 'k-')
+    sp.ax.plot([40, 10], [10, 40], 'r:')
 
     # Test ``fill``.
-    sp.fill([20, 25, 25, 20], [20, 20, 25, 25], color='blue')
+    sp.ax.fill([20, 25, 25, 20], [20, 20, 25, 25], color='blue')
 
     # Test ``scatter`` with points.
-    sp.scatter([15, 35], [15, 35], c=['magenta', 'orange'])
+    sp.ax.scatter([15, 35], [15, 35], c=['magenta', 'orange'])
 
     fname = 'plotting_routines.png'
     fig.savefig(tmp_path / fname)

--- a/tests/test_survey.py
+++ b/tests/test_survey.py
@@ -37,7 +37,7 @@ def test_survey_outlines(tmp_path, survey_tuple):
         sp.draw_maglites(label=name)
     elif name == 'DECaLS':
         sp.draw_decals(label=name)
-    sp.legend()
+    sp.ax.legend()
     fname = f'{name}_survey.png'
     fig.savefig(tmp_path / fname)
     plt.close(fig)


### PR DESCRIPTION
The old interface, with some plotting functionality accessed via skyproj and some via skyaxes was confusing.  This addresses #78 and deprecates the skyproj access in favor of skyaxes access.

Thus, `sp.plot()` is deprecated in favor of `sp.ax.plot()`.